### PR TITLE
Add title to iframe embeds

### DIFF
--- a/lib/configEmbed.js
+++ b/lib/configEmbed.js
@@ -28,7 +28,7 @@ module.exports = function(str, options) {
 
   // build the embed HTML
   let out = `<div class="${options.embedClass}">`;
-      out += `<iframe width="${options.width}" height="${options.height}" scrolling="no" frameborder="no" allow="autoplay" `;
+      out += `<iframe title="${options.iframeTitle}" width="${options.width}" height="${options.height}" scrolling="no" frameborder="no" allow="autoplay" `;
       out += `src="https://w.soundcloud.com/player/?url=${encodeURIComponent(embedUrl)}&${params}"></iframe>`;
       out += `</div>`;
 

--- a/lib/getEmbed.js
+++ b/lib/getEmbed.js
@@ -11,6 +11,8 @@ module.exports = async function(str, options) {
       duration: options.cacheDuration,
       type: 'json'
     });
+    // grab the track title for iframe a11y
+    options.iframeTitle = json.title || 'Embedded SoundCloud track';
     let out = await configEmbed(json.html, options);
     return out;
   } catch (err) {


### PR DESCRIPTION
Iframes without titles are an [accessibility error in Lighthouse tests](https://web.dev/frame-title/#how-the-lighthouse-frame-title-audit-fails). This PR ensures that all SoundCloud embeds have a meaningful title, with a generic fallback.