### PR TITLE
Update to eleventy-fetch library and test for expected embed builds

### DIFF
--- a/lib/configEmbed.js
+++ b/lib/configEmbed.js
@@ -1,5 +1,3 @@
-const parse = require('parse-path');
-
 module.exports = function(str, options) {
 
   // convenience setting to use the smaller player, overrides visual and height
@@ -12,7 +10,7 @@ module.exports = function(str, options) {
   let [, src] = str.match(/src="(.+?)"/);
   
   // parse the "url" param to get the track URL
-  let embedUrl = parse(src).query.url;
+  let embedUrl = new URL(src).searchParams.get('url');
   
   // compile the player params
   let params = '';

--- a/lib/getEmbed.js
+++ b/lib/getEmbed.js
@@ -1,4 +1,4 @@
-const Cache = require("@11ty/eleventy-cache-assets");
+const Cache = require("@11ty/eleventy-fetch");
 const sc = 'https://soundcloud.com';
 const configEmbed = require('./configEmbed.js');
 const pattern = /<p>\s*(?:<a.*>)?\s*(?:https?)?(?::\/\/)?(?:soundcloud\.com)(\/\S+?)(?:\?\S+)?\s*(?:<\/a>)?\s*<\/p>/;
@@ -19,5 +19,4 @@ module.exports = async function(str, options) {
     console.error("Error communicating with SoundCloud’s servers: ", err);
     return str;
   }
-  
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,31 +9,11 @@
       "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
-        "@11ty/eleventy-cache-assets": "^2.3.0",
         "@11ty/eleventy-fetch": "^3.0.0",
         "parse-path": "^5.0.0"
       },
       "devDependencies": {
         "ava": "^3.12.1"
-      }
-    },
-    "node_modules/@11ty/eleventy-cache-assets": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-cache-assets/-/eleventy-cache-assets-2.3.0.tgz",
-      "integrity": "sha512-W8tvO00GlWaKt3ccpEStaUBoj9BE3EgzuD8uYChCfYbN2Q4HkEItkiapvIJT0zJwAwoMfnSq6VHPLScYlX2XCg==",
-      "dependencies": {
-        "debug": "^4.3.1",
-        "flat-cache": "^3.0.4",
-        "node-fetch": "^2.6.1",
-        "p-queue": "^6.6.2",
-        "short-hash": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/11ty"
       }
     },
     "node_modules/@11ty/eleventy-fetch": {
@@ -1375,11 +1355,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/hash-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hash-string/-/hash-string-1.0.0.tgz",
-      "integrity": "sha1-w/oV8Hjd0WvBULQXb95wkWIPLH8="
-    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -2590,14 +2565,6 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
-    "node_modules/short-hash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/short-hash/-/short-hash-1.0.0.tgz",
-      "integrity": "sha1-P0kdco/Md37GBbuvf4PyNxL0IFA=",
-      "dependencies": {
-        "hash-string": "^1.0.0"
-      }
-    },
     "node_modules/signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -3100,18 +3067,6 @@
     }
   },
   "dependencies": {
-    "@11ty/eleventy-cache-assets": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-cache-assets/-/eleventy-cache-assets-2.3.0.tgz",
-      "integrity": "sha512-W8tvO00GlWaKt3ccpEStaUBoj9BE3EgzuD8uYChCfYbN2Q4HkEItkiapvIJT0zJwAwoMfnSq6VHPLScYlX2XCg==",
-      "requires": {
-        "debug": "^4.3.1",
-        "flat-cache": "^3.0.4",
-        "node-fetch": "^2.6.1",
-        "p-queue": "^6.6.2",
-        "short-hash": "^1.0.0"
-      }
-    },
     "@11ty/eleventy-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@11ty/eleventy-fetch/-/eleventy-fetch-3.0.0.tgz",
@@ -4184,11 +4139,6 @@
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
     },
-    "hash-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hash-string/-/hash-string-1.0.0.tgz",
-      "integrity": "sha1-w/oV8Hjd0WvBULQXb95wkWIPLH8="
-    },
     "hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -5126,14 +5076,6 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
-    },
-    "short-hash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/short-hash/-/short-hash-1.0.0.tgz",
-      "integrity": "sha1-P0kdco/Md37GBbuvf4PyNxL0IFA=",
-      "requires": {
-        "hash-string": "^1.0.0"
-      }
     },
     "signal-exit": {
       "version": "3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy-cache-assets": "^2.3.0",
+        "@11ty/eleventy-fetch": "^3.0.0",
         "parse-path": "^5.0.0"
       },
       "devDependencies": {
@@ -35,15 +36,22 @@
         "url": "https://opencollective.com/11ty"
       }
     },
-    "node_modules/@11ty/eleventy-cache-assets/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+    "node_modules/@11ty/eleventy-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-fetch/-/eleventy-fetch-3.0.0.tgz",
+      "integrity": "sha512-qJvfb331rYQAmlCS71Ygg0/XHUdB4/qXBOLsG0DJ1m61WL5JNha52OtKVeQq34u2J2Nfzim+X4TIL/+QyesB7Q==",
       "dependencies": {
-        "ms": "2.1.2"
+        "debug": "^4.3.3",
+        "flat-cache": "^3.0.4",
+        "node-fetch": "^2.6.7",
+        "p-queue": "^6.6.2"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/11ty"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -912,12 +920,19 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decamelize": {
@@ -3095,16 +3110,17 @@
         "node-fetch": "^2.6.1",
         "p-queue": "^6.6.2",
         "short-hash": "^1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
+      }
+    },
+    "@11ty/eleventy-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-fetch/-/eleventy-fetch-3.0.0.tgz",
+      "integrity": "sha512-qJvfb331rYQAmlCS71Ygg0/XHUdB4/qXBOLsG0DJ1m61WL5JNha52OtKVeQq34u2J2Nfzim+X4TIL/+QyesB7Q==",
+      "requires": {
+        "debug": "^4.3.3",
+        "flat-cache": "^3.0.4",
+        "node-fetch": "^2.6.7",
+        "p-queue": "^6.6.2"
       }
     },
     "@babel/code-frame": {
@@ -3813,12 +3829,11 @@
       }
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
-        "@11ty/eleventy-fetch": "^3.0.0",
-        "parse-path": "^5.0.0"
+        "@11ty/eleventy-fetch": "^3.0.0"
       },
       "devDependencies": {
         "ava": "^3.12.1"
@@ -346,6 +345,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -521,6 +523,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/boxen/node_modules/chalk": {
@@ -600,6 +605,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cacheable-request/node_modules/lowercase-keys": {
@@ -640,6 +648,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -727,6 +738,9 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-truncate": {
@@ -740,6 +754,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cliui": {
@@ -1047,6 +1064,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
     },
     "node_modules/emoji-regex": {
@@ -1169,6 +1189,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fill-range": {
@@ -1222,7 +1245,9 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1266,6 +1291,9 @@
       },
       "engines": {
         "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -1307,6 +1335,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/got": {
@@ -1534,6 +1565,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -1755,6 +1789,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-dir/node_modules/semver": {
@@ -1797,6 +1834,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/md5-hex": {
@@ -1977,6 +2017,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ora": {
@@ -1996,6 +2039,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-cancelable": {
@@ -2034,6 +2080,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
@@ -2058,6 +2107,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-queue": {
@@ -2070,6 +2122,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-timeout": {
@@ -2138,14 +2193,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-5.0.0.tgz",
-      "integrity": "sha512-qOpH55/+ZJ4jUu/oLO+ifUKjFPNZGfnPJtzvGzKN/4oLMil5m9OH4VpOj6++9/ytJcfks4kzH2hhi87GL/OU9A==",
-      "dependencies": {
-        "protocols": "^2.0.0"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2185,6 +2232,9 @@
       "dev": true,
       "engines": {
         "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/pify": {
@@ -2277,6 +2327,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prepend-http": {
@@ -2298,12 +2351,10 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/protocols": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
-      "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q=="
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -2370,6 +2421,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
@@ -2439,6 +2493,9 @@
       "dev": true,
       "dependencies": {
         "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-cwd": {
@@ -2503,6 +2560,9 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/run-parallel": {
@@ -2799,6 +2859,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/time-zone": {
@@ -2897,6 +2960,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/yeoman/update-notifier?sponsor=1"
       }
     },
     "node_modules/update-notifier/node_modules/chalk": {
@@ -4744,14 +4810,6 @@
       "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
       "dev": true
     },
-    "parse-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-5.0.0.tgz",
-      "integrity": "sha512-qOpH55/+ZJ4jUu/oLO+ifUKjFPNZGfnPJtzvGzKN/4oLMil5m9OH4VpOj6++9/ytJcfks4kzH2hhi87GL/OU9A==",
-      "requires": {
-        "protocols": "^2.0.0"
-      }
-    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4865,11 +4923,6 @@
       "requires": {
         "parse-ms": "^2.1.0"
       }
-    },
-    "protocols": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
-      "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q=="
     },
     "pump": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "ava": "^3.12.1"
   },
   "dependencies": {
-    "@11ty/eleventy-fetch": "^3.0.0",
-    "parse-path": "^5.0.0"
+    "@11ty/eleventy-fetch": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@11ty/eleventy-cache-assets": "^2.3.0",
+    "@11ty/eleventy-fetch": "^3.0.0",
     "parse-path": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "ava": "^3.12.1"
   },
   "dependencies": {
-    "@11ty/eleventy-cache-assets": "^2.3.0",
     "@11ty/eleventy-fetch": "^3.0.0",
     "parse-path": "^5.0.0"
   }

--- a/test/getEmbed.test.js
+++ b/test/getEmbed.test.js
@@ -1,0 +1,27 @@
+const test = require('ava');
+const getEmbed = require('../lib/getEmbed.js');
+const pluginDefaults = require('../lib/pluginDefaults.js');
+
+const artistUrl = '<p>https://soundcloud.com/earlxsweatshirtmusic</p>';
+const trackUrl = '<p>https://soundcloud.com/earlxsweatshirtmusic/tisktisk-cookies</p>';
+const setUrl = '<p>https://soundcloud.com/earlxsweatshirtmusic/sets/earl-15</p>';
+const expectedArtistOutput = '<div class="eleventy-plugin-embed-soundcloud"><iframe title="Earl Sweatshirt" width="100%" height="400" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Fusers%2F24883142&auto_play=false&cacheDuration=5m&color=%23ff7700&sharing=true&show_artwork=true&show_comments=true&show_playcount=true&show_reposts=false&show_teaser=false&show_user=true&single_active=true&visual=true&iframeTitle=Earl%20Sweatshirt&"></iframe></div>';
+const expectedTrackOutput = '<div class="eleventy-plugin-embed-soundcloud"><iframe title="TISK TISK / COOKIES by Earl Sweatshirt" width="100%" height="400" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F706125730&auto_play=false&cacheDuration=5m&color=%23ff7700&sharing=true&show_artwork=true&show_comments=true&show_playcount=true&show_reposts=false&show_teaser=false&show_user=true&single_active=true&visual=true&iframeTitle=TISK%20TISK%20%2F%20COOKIES%20by%20Earl%20Sweatshirt&"></iframe></div>';
+const expectedSetOutput = '<div class="eleventy-plugin-embed-soundcloud"><iframe title="Earl by Earl Sweatshirt" width="100%" height="400" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Fplaylists%2F284902110&auto_play=false&cacheDuration=5m&color=%23ff7700&sharing=true&show_artwork=true&show_comments=true&show_playcount=true&show_reposts=false&show_teaser=false&show_user=true&single_active=true&visual=true&iframeTitle=Earl%20by%20Earl%20Sweatshirt&"></iframe></div>';
+
+
+/**
+ * For the three supported URL types, check that the plugin produces the expected markup
+ */
+test(`Artist URL`, async t => {
+  let out = await getEmbed(artistUrl, pluginDefaults);
+  t.is(out, expectedArtistOutput);
+});
+test(`Track URL`, async t => {
+  let out = await getEmbed(trackUrl, pluginDefaults);
+  t.is(out, expectedTrackOutput);
+});
+test(`Set URL`, async t => {
+  let out = await getEmbed(setUrl, pluginDefaults);
+  t.is(out, expectedSetOutput);
+});

--- a/test/getEmbed.test.js
+++ b/test/getEmbed.test.js
@@ -5,13 +5,20 @@ const pluginDefaults = require('../lib/pluginDefaults.js');
 const artistUrl = '<p>https://soundcloud.com/earlxsweatshirtmusic</p>';
 const trackUrl = '<p>https://soundcloud.com/earlxsweatshirtmusic/tisktisk-cookies</p>';
 const setUrl = '<p>https://soundcloud.com/earlxsweatshirtmusic/sets/earl-15</p>';
+const badUrl = '<p>https://soundcloud.com/earlxsweatshirtmusicbutnonexistent</p>';
 const expectedArtistOutput = '<div class="eleventy-plugin-embed-soundcloud"><iframe title="Earl Sweatshirt" width="100%" height="400" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Fusers%2F24883142&auto_play=false&cacheDuration=5m&color=%23ff7700&sharing=true&show_artwork=true&show_comments=true&show_playcount=true&show_reposts=false&show_teaser=false&show_user=true&single_active=true&visual=true&iframeTitle=Earl%20Sweatshirt&"></iframe></div>';
 const expectedTrackOutput = '<div class="eleventy-plugin-embed-soundcloud"><iframe title="TISK TISK / COOKIES by Earl Sweatshirt" width="100%" height="400" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F706125730&auto_play=false&cacheDuration=5m&color=%23ff7700&sharing=true&show_artwork=true&show_comments=true&show_playcount=true&show_reposts=false&show_teaser=false&show_user=true&single_active=true&visual=true&iframeTitle=TISK%20TISK%20%2F%20COOKIES%20by%20Earl%20Sweatshirt&"></iframe></div>';
 const expectedSetOutput = '<div class="eleventy-plugin-embed-soundcloud"><iframe title="Earl by Earl Sweatshirt" width="100%" height="400" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Fplaylists%2F284902110&auto_play=false&cacheDuration=5m&color=%23ff7700&sharing=true&show_artwork=true&show_comments=true&show_playcount=true&show_reposts=false&show_teaser=false&show_user=true&single_active=true&visual=true&iframeTitle=Earl%20by%20Earl%20Sweatshirt&"></iframe></div>';
 
+const smallPlayer = Object.assign({}, pluginDefaults, {small: true});
+const expectedArtistOutput_sm = '<div class="eleventy-plugin-embed-soundcloud"><iframe title="Earl Sweatshirt" width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Fusers%2F24883142&auto_play=false&cacheDuration=5m&color=%23ff7700&sharing=true&show_artwork=true&show_comments=true&show_playcount=true&show_reposts=false&show_teaser=false&show_user=true&single_active=true&visual=false&iframeTitle=Earl%20Sweatshirt&"></iframe></div>';
+const expectedTrackOutput_sm = '<div class="eleventy-plugin-embed-soundcloud"><iframe title="TISK TISK / COOKIES by Earl Sweatshirt" width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F706125730&auto_play=false&cacheDuration=5m&color=%23ff7700&sharing=true&show_artwork=true&show_comments=true&show_playcount=true&show_reposts=false&show_teaser=false&show_user=true&single_active=true&visual=false&iframeTitle=TISK%20TISK%20%2F%20COOKIES%20by%20Earl%20Sweatshirt&"></iframe></div>';
+const expectedSetOutput_sm = '<div class="eleventy-plugin-embed-soundcloud"><iframe title="Earl by Earl Sweatshirt" width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Fplaylists%2F284902110&auto_play=false&cacheDuration=5m&color=%23ff7700&sharing=true&show_artwork=true&show_comments=true&show_playcount=true&show_reposts=false&show_teaser=false&show_user=true&single_active=true&visual=false&iframeTitle=Earl%20by%20Earl%20Sweatshirt&"></iframe></div>';
+
 
 /**
- * For the three supported URL types, check that the plugin produces the expected markup
+ * For the three supported URL types, check that the plugin produces 
+ * the expected markup
  */
 test(`Artist URL`, async t => {
   let out = await getEmbed(artistUrl, pluginDefaults);
@@ -24,4 +31,29 @@ test(`Track URL`, async t => {
 test(`Set URL`, async t => {
   let out = await getEmbed(setUrl, pluginDefaults);
   t.is(out, expectedSetOutput);
+});
+
+/**
+ * For the three supported URL types, check that the plugin produces 
+ * the expected markup with the "small" embed type specified
+ */
+test(`Artist URL, small version`, async t => {
+  let out = await getEmbed(artistUrl, smallPlayer);
+  t.is(out, expectedArtistOutput_sm);
+});
+test(`Track URL, small version`, async t => {
+  let out = await getEmbed(trackUrl, smallPlayer);
+  t.is(out, expectedTrackOutput_sm);
+});
+test(`Set URL, small version`, async t => {
+  let out = await getEmbed(setUrl, smallPlayer);
+  t.is(out, expectedSetOutput_sm);
+});
+
+/**
+ * On request failure, return the URL unchanged
+ */
+test(`oEmbed fetch failure`, async t => {
+  let out = await getEmbed(badUrl, pluginDefaults);
+  t.is(out, badUrl);
 });

--- a/test/inc/validUrls.js
+++ b/test/inc/validUrls.js
@@ -1,6 +1,6 @@
 /**
  * VALID URLS
- * 
+ *
  * Starting with a short list of valid URL fragments, return
  * all possible valid URL permutations.
  */
@@ -9,7 +9,7 @@ const permute = require('./permuteArrays.js');
 
 /**
  * Core URL structures accepted by the plugin
- * Domain and path only 
+ * Domain and path only
  */
 const validUrls = [
   'soundcloud.com/earlxsweatshirtmusic',


### PR DESCRIPTION
This PR does several things:

- Migrates from @11ty/eleventy-cache-assets to @11ty/eleventy-fetch
- Removes `parse-path` dependency
- Adds tests for the plugin's embed-build step

I opted to do these steps together because I needed the tests in order to know that swapping the caching library and deprecating the URL-parsing library still produced results at parity.