### PR TITLE
Remove testing for unsupported Node versions

### DIFF
--- a/.github/workflows/test-and-codecov.yml
+++ b/.github/workflows/test-and-codecov.yml
@@ -6,12 +6,12 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        node: ["8", "10", "12", "14"]
+        node: ["12", "14", "16", "18", "19"]
     name: Node.js ${{ matrix.node }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - name: Run tests using ava
@@ -19,5 +19,5 @@ jobs:
           npm ci
           npx nyc --reporter=lcov ava
       - name: Upload coverage to Codecov.io
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
       


### PR DESCRIPTION
See https://github.com/gfscott/eleventy-plugin-embed-everything/discussions/103

In addition, this PR bumps the versions of the Actions being used in CI.